### PR TITLE
Un-harcode paths in the driver and tracking subprocess, add build instructions to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,34 @@
 # SteamVR driver for Mercury hand tracking!
 
 This is very in-development. Check back later!
+
+## Build Instructions
+
+Prerequisites:
+- vcpkg
+- CMake
+- Ninja
+- clang
+- Visual Studio 2019, or 2022
+
+### Clone the repository
+```
+git clone https://github.com/moshimeow/mercury_steamvr_driver.git --recursive
+cd mercury_steamvr_driver
+git submodule init
+```
+
+### Download onnx
+```
+powershell .\attic\moshi_get_onnxruntime.ps1
+```
+
+### Set your vcpkg path
+Edit the `vcpkgdir` variable in [attic/moshi_build.ps1](attic/moshi_build.ps1) to reflect your vcpkg path.
+
+### Build the project
+```
+powershell .\attic\moshi_build.ps1
+```
+
+Once this has completed, copy `onnxruntime.dll` from the `deps` folder to `build/mercury/bin/win64/`.

--- a/src/steamvr_driver/device_provider.cpp
+++ b/src/steamvr_driver/device_provider.cpp
@@ -49,9 +49,11 @@ bool DeviceProvider::StartSubprocess()
     // maybe this is bad?
     // startupInfo.wShowWindow = true;
 
+    std::string rootpath;
     std::string subprocessPath = {};
+    GetDriverRootPath(rootpath);
     GetSubprocessPath(subprocessPath);
-    std::string commandLine = subprocessPath + " " + std::to_string(ntohs(localAddr.sin_port)) + " " + hmd_config;
+    std::string commandLine = subprocessPath + " " + std::to_string(ntohs(localAddr.sin_port)) + " \"" + hmd_config + "\" \"" + rootpath + "\" \"" + rootpath + "\\debug.txt\"";
     std::wstring wideCommandLine(commandLine.begin(), commandLine.end());
     DriverLog("Creating subprocess %s!", commandLine.c_str());
     if (!CreateProcess(NULL, commandLine.data(), NULL, NULL, FALSE, 0, NULL, NULL, &startupInfo, &processInfo))

--- a/src/steamvr_driver/tracking_subprocess.cpp
+++ b/src/steamvr_driver/tracking_subprocess.cpp
@@ -59,6 +59,8 @@
 
 namespace xat = xrt::auxiliary::tracking;
 
+static char* rootpath = NULL;
+
 struct subprocess_state
 {
     const char *port;
@@ -174,8 +176,11 @@ bool setup_camera_and_ht(subprocess_state &state)
     info.views[0].boundary.circle.normalized_radius = 0.55;
     info.views[1].boundary.circle.normalized_radius = 0.55;
 
+    char rpath[512];
+    strcpy(rpath, rootpath);
+    strcat(rpath, "\\resources\\internal\\hand-tracking-models\\");
     state.sync =
-        t_hand_tracking_sync_mercury_create(calib, info, "C:\\dev\\mercury_steamvr_driver\\src\\steamvr_driver\\mercury\\resources\\internal\\hand-tracking-models\\");
+        t_hand_tracking_sync_mercury_create(calib, info, rpath);
 
     xrt_frame_context blah = {};
 
@@ -422,9 +427,9 @@ int main(int argc, char **argv)
 {
     meow_printf("Starting!");
 
-    if (argc < 3)
+    if (argc < 4)
     {
-        U_SP_LOG_E("Need a port and vive config location");
+        U_SP_LOG_E("Need a port, vive config location, and root path");
         meow_exit();
     }
     subprocess_state state = {};
@@ -433,6 +438,11 @@ int main(int argc, char **argv)
 
     state.port = argv[1];
     state.vive_config_location = argv[2];
+    rootpath = argv[3];
+
+    if (argc >= 5) {
+        u_sp_log_set_file_path(argv[4]);
+    }
 
     vr::EVRInitError error;
 

--- a/src/util/u_subprocess_logging.c
+++ b/src/util/u_subprocess_logging.c
@@ -33,6 +33,11 @@ static u_sp_log_sink_func_t g_log_sink_func;
 static void *g_log_sink_data;
 
 static FILE* out_file = NULL;
+static char* out_file_path = NULL;
+
+void u_sp_log_set_file_path(char* path) {
+	out_file_path = path;
+}
 
 void
 u_sp_log_set_sink(u_sp_log_sink_func_t func, void *data)
@@ -50,10 +55,9 @@ u_sp_log_set_sink(u_sp_log_sink_func_t func, void *data)
 	}
 
 void handle_file() {
-    out_file = fopen("C:\\dev\\debug.txt", "w");
-    if (!out_file) {
-        abort();
-    }
+	if (out_file_path != NULL) {
+    	out_file = fopen(out_file_path, "w");
+	}
 }
 
 static int
@@ -101,7 +105,9 @@ u_sp_log(const char *file, int line, const char *func, enum u_sp_logging_level l
 	buf[printed++] = '\0';
 	OutputDebugStringA(buf);
 	fprintf(stderr, "%s", buf);
-    fprintf(out_file, "%s", buf);
-    fflush(out_file);
+	if (out_file) {
+    	fprintf(out_file, "%s", buf);
+    	fflush(out_file);
+	}
 }
 

--- a/src/util/u_subprocess_logging.h
+++ b/src/util/u_subprocess_logging.h
@@ -117,6 +117,13 @@ u_sp_log(const char *file, int line, const char *func, enum u_sp_logging_level l
     XRT_PRINTF_FORMAT(5, 6);
 
 /*!
+ * Sets the path to the log file
+ *
+ * @param path Output file to log to
+*/
+void u_sp_log_set_file_path(char* path);
+
+/*!
  * Sets the logging sink, log is still passed on to the platform defined output
  * as well as the sink.
  *


### PR DESCRIPTION
Pretty much what the title says. Because of how I am passing the path to the driver to the tracking subprocess, it may be viable to reduce some extra redundancy. Note that I only removed the hardcoded paths from the driver and tracking subprocess, so there are still hardcoded paths in things like tests.