### PR TITLE
Enable build script to find VS2022

### DIFF
--- a/attic/moshi_build.ps1
+++ b/attic/moshi_build.ps1
@@ -33,7 +33,7 @@ Write-Output "sourcedir:$sourcedir"
 Write-Output "toolchainfile:$toolchainfile"
 
 # I don't understand this at all. This string ends up finding VS 2019 on my machine (but *NOT* VS 2022, which is what we want), and may work for yours. Patches very welcome.
-$version = '[16.0,17.0]'
+$version = '[16.0,18.0]'
 $installPath = & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -version $version -property installationpath
 Write-Output "vswhere.exe installPath: $installPath"
 # $installPath = "C:\BuildTools"


### PR DESCRIPTION
This PR updates the version range that `vswhere` searches to include v18, aka VS 2022.